### PR TITLE
Add basic NixOS tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,6 +148,14 @@
         username = "trivaris";
       };
 
+      nixosTests = forAllSystems (
+        system:
+          {
+            openssh = import ./tests/openssh.nix { inherit inputs system; };
+            hyprland = import ./tests/hyprland.nix { inherit inputs system; };
+          }
+      );
+
     };
 
 }

--- a/tests/hyprland.nix
+++ b/tests/hyprland.nix
@@ -1,0 +1,20 @@
+{ inputs, system ? "x86_64-linux" }:
+let
+  pkgs = import inputs.nixpkgs { inherit system; };
+  makeTest = import (inputs.nixpkgs + "/nixos/tests/make-test-python.nix") { inherit pkgs; };
+in
+makeTest ({ pkgs, ... }:
+{
+  name = "hyprland-module";
+  nodes.machine = { pkgs, ... }:
+    {
+      imports = [
+        ../hosts/laptop/system-packages.nix
+      ];
+    };
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("command -v Hyprland")
+  '';
+})

--- a/tests/openssh.nix
+++ b/tests/openssh.nix
@@ -1,0 +1,20 @@
+{ inputs, system ? "x86_64-linux" }:
+let
+  pkgs = import inputs.nixpkgs { inherit system; };
+  makeTest = import (inputs.nixpkgs + "/nixos/tests/make-test-python.nix") { inherit pkgs; };
+in
+makeTest ({ pkgs, ... }:
+{
+  name = "openssh-module";
+  nodes.machine = { pkgs, ... }:
+    {
+      imports = [
+        ../hosts/wsl/system-packages.nix
+      ];
+    };
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("sshd.service")
+    machine.succeed("pgrep sshd")
+  '';
+})


### PR DESCRIPTION
## Summary
- add simple NixOS tests for openssh and hyprland modules
- expose tests through the flake outputs

## Testing
- `nix flake check --no-build` *(fails: cannot look up '<nixos-wsl/modules>')*

------
https://chatgpt.com/codex/tasks/task_e_68408a5d35bc8324a13dbab994295f4e